### PR TITLE
Fix issue 21

### DIFF
--- a/include/giskard_core/expression_generation.hpp
+++ b/include/giskard_core/expression_generation.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2017 Georg Bartels <georg.bartels@cs.uni-bremen.de>
+ *                         Adrian Röfer <aroefer@uni-bremen.de>
  * 
  * This file is part of giskard.
  * 
@@ -49,6 +50,23 @@ namespace giskard_core
       else if(boost::dynamic_pointer_cast<giskard_core::RotationSpec>(spec).get())
         scope.add_rotation_expression(name,
             boost::dynamic_pointer_cast<giskard_core::RotationSpec>(spec)->get_expression(scope));
+      else if(boost::dynamic_pointer_cast<giskard_core::AliasReferenceSpec>(spec).get())
+      {
+        // generation of alias references is extraordinarily convoluted;
+        // it is a feature that was added relatively late... sorry!
+        KDL::ExpressionBase::Ptr exp =
+          boost::dynamic_pointer_cast<giskard_core::AliasReferenceSpec>(spec)->get_expression(scope);
+        if (boost::dynamic_pointer_cast<KDL::Expression<double>>(exp).get())
+          scope.add_double_expression(name, boost::dynamic_pointer_cast<KDL::Expression<double>>(exp));
+        else if (boost::dynamic_pointer_cast<KDL::Expression<KDL::Vector>>(exp).get())
+          scope.add_vector_expression(name, boost::dynamic_pointer_cast<KDL::Expression<KDL::Vector>>(exp));
+        else if (boost::dynamic_pointer_cast<KDL::Expression<KDL::Rotation>>(exp).get())
+          scope.add_rotation_expression(name, boost::dynamic_pointer_cast<KDL::Expression<KDL::Rotation>>(exp));
+        else if (boost::dynamic_pointer_cast<KDL::Expression<KDL::Frame>>(exp).get())
+          scope.add_frame_expression(name, boost::dynamic_pointer_cast<KDL::Expression<KDL::Frame>>(exp));
+        else
+          throw std::domain_error("Error during generation of alias reference! Could not cast into any existing expression type. This is an giskard-internal error that should not happen.");
+      }
       else
         throw std::domain_error("Scope generation: found entry of non-supported type.");
     }

--- a/include/giskard_core/scope.hpp
+++ b/include/giskard_core/scope.hpp
@@ -76,6 +76,21 @@ namespace giskard_core
         return it->second;
       }
 
+      const KDL::ExpressionBase::Ptr find_expression(const std::string& reference_name) const
+      {
+        if(!has_expression(reference_name))
+          throw std::invalid_argument("Could not find expression with name: "+ reference_name);
+
+        if (has_double_expression(reference_name))
+          return find_double_expression(reference_name);
+        else if (has_vector_expression(reference_name))
+          return find_vector_expression(reference_name);
+        else if (has_rotation_expression(reference_name))
+          return find_rotation_expression(reference_name);
+        else if (has_frame_expression(reference_name))
+          return find_frame_expression(reference_name);
+      }
+
       bool has_double_expression(const std::string& expression_name) const
       {
         return (double_references_.count(expression_name) == 1);
@@ -94,6 +109,14 @@ namespace giskard_core
       bool has_frame_expression(const std::string& expression_name) const
       {
         return (frame_references_.count(expression_name) == 1);
+      }
+
+      bool has_expression (const std::string& expression_name) const
+      {
+        return has_double_expression(expression_name) ||
+          has_vector_expression(expression_name) || 
+          has_rotation_expression(expression_name) ||
+          has_frame_expression(expression_name);
       }
 
       void add_double_expression(const std::string& reference_name, const KDL::Expression<double>::Ptr& expression)

--- a/include/giskard_core/specifications.hpp
+++ b/include/giskard_core/specifications.hpp
@@ -56,6 +56,48 @@ namespace giskard_core
   /// next level of expression specifications
   ///
 
+  class AliasReferenceSpec: public Spec
+  {
+    public:
+      AliasReferenceSpec() : reference_name_( "" ) {}
+      AliasReferenceSpec(const std::string& reference_name) : 
+        reference_name_( reference_name ) {}
+      AliasReferenceSpec(const AliasReferenceSpec& other) : 
+        reference_name_ ( other.get_reference_name() ) {}
+
+      const std::string& get_reference_name() const
+      {
+        return reference_name_;
+      }
+
+      void set_reference_name(const std::string& reference_name)
+      {
+        reference_name_ = reference_name;
+      }
+
+      bool equals(const Spec& other) const
+      {
+        if(!dynamic_cast<const AliasReferenceSpec*>(&other))
+          return false;
+  
+        return (dynamic_cast<const AliasReferenceSpec*>(&other)->get_reference_name().compare(this->get_reference_name()) == 0);
+      }
+  
+      KDL::ExpressionBase::Ptr get_expression(const giskard_core::Scope& scope)
+      {
+        return scope.find_expression(get_reference_name());
+      }
+    private:
+      std::string reference_name_;
+  };
+
+  typedef typename boost::shared_ptr<AliasReferenceSpec> AliasReferenceSpecPtr;
+
+  inline AliasReferenceSpecPtr alias_reference_spec(const std::string& reference_name = "")
+  {
+    return AliasReferenceSpecPtr(new AliasReferenceSpec(reference_name));
+  }
+
   class DoubleSpec : public Spec
   {
     public:

--- a/test/giskard_core/yaml_parser.cpp
+++ b/test/giskard_core/yaml_parser.cpp
@@ -916,3 +916,41 @@ TEST_F(YamlParserTest, QPControllerSpec)
   EXPECT_DOUBLE_EQ(spec.hard_constraints_[0].upper_->get_expression(giskard_core::Scope())->value(), 110.3);
   EXPECT_DOUBLE_EQ(spec.hard_constraints_[0].expression_->get_expression(giskard_core::Scope())->value(), 17.1);
 }
+
+TEST_F(YamlParserTest, AliasTest)
+{
+  std::string sc = "scope: [a: 10, b: {vector3: [1,0,0]}, c: {quaternion: [0,0,0,1]}, d: {frame: [c, b]}, \
+                                                  aliasA: a, aliasB: b, aliasC: c, aliasD: d, \
+                                                  aliasAA: aliasA, aliasBB: aliasB, aliasCC: aliasC, aliasDD: aliasD]";
+  std::string co = "controllable-constraints: [{controllable-constraint: [-0.1, 0.2, 5.0, 2, controllable1]}]";
+  std::string so = "soft-constraints: [{soft-constraint: [-10.1, 120.2, 5.0, 1.1, goal1]}]";
+  std::string ha = "hard-constraints: [{hard-constraint: [-33.1, 110.3, 17.1]}]";
+
+  std::string s = sc + "\n" + co + "\n" + so + "\n" + ha;
+
+  ASSERT_NO_THROW(YAML::Load(s));
+  YAML::Node node = YAML::Load(s);
+
+  giskard_core::Scope scope; 
+  ASSERT_NO_THROW(scope = giskard_core::generate(node.as<giskard_core::QPControllerSpec>().scope_));
+
+  ASSERT_TRUE(scope.has_double_expression("a"));
+  ASSERT_TRUE(scope.has_vector_expression("b"));
+  ASSERT_TRUE(scope.has_rotation_expression("c"));
+  ASSERT_TRUE(scope.has_frame_expression("d"));
+
+  ASSERT_TRUE(scope.has_double_expression("aliasA"));
+  ASSERT_TRUE(scope.has_vector_expression("aliasB"));
+  ASSERT_TRUE(scope.has_rotation_expression("aliasC"));
+  ASSERT_TRUE(scope.has_frame_expression("aliasD"));
+
+  ASSERT_TRUE(scope.has_double_expression("aliasAA"));
+  ASSERT_TRUE(scope.has_vector_expression("aliasBB"));
+  ASSERT_TRUE(scope.has_rotation_expression("aliasCC"));
+  ASSERT_TRUE(scope.has_frame_expression("aliasDD"));
+
+  EXPECT_EQ(scope.find_double_expression("a").get(), scope.find_double_expression("aliasAA").get());
+  EXPECT_EQ(scope.find_vector_expression("b").get(), scope.find_vector_expression("aliasBB").get());
+  EXPECT_EQ(scope.find_rotation_expression("c").get(), scope.find_rotation_expression("aliasCC").get());
+  EXPECT_EQ(scope.find_frame_expression("d").get(), scope.find_frame_expression("aliasDD").get());
+}


### PR DESCRIPTION
Fixes SemRoCo/giskard_core#21. Replaces PR SemRoCo/giskard_core#31 

Introduces a new type expression specification: ```AliasReferenceSpec``` that comes with its own representation, parsing, and generation. Also supports indefinitely long chains of alias references. @ARoefer what do you think?